### PR TITLE
Setting productID on account only if it has one for updateAccount req

### DIFF
--- a/Sources/Model/Core Data/Aggregation/Account+CoreDataClass.swift
+++ b/Sources/Model/Core Data/Aggregation/Account+CoreDataClass.swift
@@ -680,7 +680,7 @@ public class Account: NSManagedObject, UniqueManagedObject {
                                        hidden: hidden,
                                        included: included,
                                        nickName: nickName,
-                                       productID: productID)
+                                       productID: productID != -1 ? productID : nil)
     }
     
 }

--- a/Sources/Model/Core Data/Aggregation/Provider+CoreDataClass.swift
+++ b/Sources/Model/Core Data/Aggregation/Provider+CoreDataClass.swift
@@ -128,7 +128,7 @@ public class Provider: NSManagedObject, UniqueManagedObject {
         
         /// Direct API connection via the Consumer Data Right (Open Banking) regime
         case cdr
-
+        
         /// Demo providers used for testing and demos
         case demo
         


### PR DESCRIPTION
Background: 
Update account request for Yodlee aggregated accounts was failing as they wouldn't have a crd product id and was sending -1 (default value) causing it to fail. 