### PR TITLE
Fallback merchant type to .unknown and add empty response code 

### DIFF
--- a/Sources/Model/Core Data/Aggregation/Merchant+CoreDataClass.swift
+++ b/Sources/Model/Core Data/Aggregation/Merchant+CoreDataClass.swift
@@ -54,7 +54,7 @@ public class Merchant: NSManagedObject, UniqueManagedObject {
     /// Type of merchant
     public var merchantType: MerchantType {
         get {
-            return MerchantType(rawValue: merchantTypeRawValue!)!
+            return MerchantType(rawValue: merchantTypeRawValue ?? "") ?? .unknown
         }
         set {
             merchantTypeRawValue = newValue.rawValue

--- a/Sources/Network/API/Requests/APIService+Events.swift
+++ b/Sources/Network/API/Requests/APIService+Events.swift
@@ -32,7 +32,7 @@ extension APIService {
                 return
             }
             
-            self.network.sessionManager.request(urlRequest).validate(statusCode: 200...299).responseData(queue: self.responseQueue, completionHandler: { response in
+            self.network.sessionManager.request(urlRequest).validate(statusCode: 200...299).responseData(queue: self.responseQueue, emptyResponseCodes: [201], completionHandler: { response in
                 self.network.handleEmptyResponse(errorType: APIError.self, response: response, completion: completion)
             })
         }

--- a/Tests/Aggregation/AggregationTests.swift
+++ b/Tests/Aggregation/AggregationTests.swift
@@ -4615,6 +4615,35 @@ class AggregationTests: BaseTestCase {
         }
         
     }
+    
+    func testMerchantTypeFallBack() {
+        let expectation1 = expectation(description: "Completion")
+        
+        let aggregation = self.aggregation(loggedIn: true)
+        
+        database.setup { error in
+            XCTAssertNil(error)
+            
+            let managedObjectContext = self.database.newBackgroundContext()
+            
+            managedObjectContext.performAndWait {
+                let testMerchant1 = Merchant(context: managedObjectContext)
+                testMerchant1.populateTestData()
+                testMerchant1.merchantTypeRawValue = nil
+                
+                try! managedObjectContext.save()
+            }
+            
+            let merchant = aggregation.merchants(context: self.context)?.first
+            
+            XCTAssertNotNil(merchant)
+            XCTAssertEqual(merchant?.merchantType, .unknown)
+            
+            expectation1.fulfill()
+        }
+        
+        wait(for: [expectation1], timeout: 3.0)
+    }
 }
 
 


### PR DESCRIPTION
Fallback merchant type to .unknown and add empty response code for event API