### PR TITLE
Update log files director to shared appgroups directory

### DIFF
--- a/Sources/FrolloSDK/FrolloSDK.swift
+++ b/Sources/FrolloSDK/FrolloSDK.swift
@@ -321,6 +321,7 @@ public class Frollo: OAuth2AuthenticationDelegate, UserManagementDelegate {
             }
         }
         
+        Log.logDataFolderURL = configuration.dataDirectory
         _database = Database(path: configuration.dataDirectory, targetName: configuration.targetName)
         preferences = Preferences(path: configuration.dataDirectory)
         version = Version(path: configuration.dataDirectory, keychain: keychain)

--- a/Sources/FrolloSDK/Logging/Log.swift
+++ b/Sources/FrolloSDK/Logging/Log.swift
@@ -41,6 +41,7 @@ public enum LogLevel: Int, Codable {
 class Log {
     
     internal static let manager = Log(synchronous: false)
+    internal static var logDataFolderURL: URL = Frollo.defaultDataFolderURL
     
     struct LogConstants {
         static let fileName = Bundle(for: Log.self).bundleIdentifier!
@@ -59,13 +60,13 @@ class Log {
     private let queue = DispatchQueue(label: "Logging", qos: .utility)
     
     private let logFilePath: URL = {
-        var logFileURL = Frollo.defaultDataFolderURL.appendingPathComponent(LogConstants.fileName)
+        var logFileURL = logDataFolderURL.appendingPathComponent(LogConstants.fileName)
         logFileURL.appendPathExtension(LogConstants.logExtension)
         return logFileURL
     }()
     
     private let previousLogFilePath: URL = {
-        var logFileURL = Frollo.defaultDataFolderURL
+        var logFileURL = logDataFolderURL
         let fileName = LogConstants.fileName.appending(LogConstants.previousFileSuffix)
         logFileURL.appendPathComponent(fileName)
         logFileURL.appendPathExtension(LogConstants.logExtension)


### PR DESCRIPTION
Log file was left out while moving directory because it always defaulted to default directory set in SDK. This change will make sure log file will be in app group shared directory if provided by client app.